### PR TITLE
Add Not Human Search to Industry-Leading Products

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Whether you're a researcher, developer, or enthusiast, this repository is your g
 - 🦌 [DeerFlow](https://deerflow.tech/): ByteDance's research and analysis solution (May 9, 2025)
 - <img src="https://www.google.com/s2/favicons?sz=24&domain_url=chat.qwen.ai" width="16" style="vertical-align: -15px;"/> [Deep Research](https://chat.qwen.ai/?inputFeature=deep_research): Alibaba's Qwen-powered research assistant (May 14, 2025)
 - <img src="https://www.google.com/s2/favicons?sz=24&domain_url=moonshot.cn" width="16" style="vertical-align: -10px;"/> [Kimi-Researcher](https://moonshotai.github.io/Kimi-Researcher/): Moonshot's research assistant powered by Kimi (June 20, 2025)
+- <img src="https://www.google.com/s2/favicons?sz=24&domain_url=nothumansearch.ai" width="20" style="vertical-align: -10px;"/> [Not Human Search](https://nothumansearch.ai): Search engine for AI agents. Indexes 1,400+ agent-first tools ranked by agentic readiness (MCP, OpenAPI, structured API signals). Available as MCP server for tool discovery.
 
 
 ## Open-Source Implementations


### PR DESCRIPTION
## What is Not Human Search?

[Not Human Search](https://nothumansearch.ai) is a search engine purpose-built for AI agents. It indexes 1,400+ agent-first tools and ranks them by agentic readiness using signals like MCP support, OpenAPI specs, and structured API availability.

## Why it fits this list

Not Human Search is directly relevant to the agentic deep research ecosystem:

- **Search engine for agents**: Helps research agents discover tools and APIs programmatically
- **MCP server**: Published in the official MCP registry, enabling deep research agents to discover and evaluate tools during research workflows
- **Agentic readiness scoring**: Ranks tools by how well they support agent integration (MCP, OpenAPI, llms.txt, ai-plugin.json)
- **Agent-first design**: Built specifically for non-human consumers, complementing the deep research products already listed

It fits the Industry-Leading Products section as a production search platform that serves the agent tool discovery use case.