### PR TITLE
Add Local Deep Research to Open-Source Implementations

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Whether you're a researcher, developer, or enthusiast, this repository is your g
 - [OpenManus](https://github.com/FoundationAgents/OpenManus): An open-source framework for building general AI agents. ![GitHub Repo stars](https://img.shields.io/github/stars/FoundationAgents/OpenManus?style=social)
 - [PraisonAI](https://github.com/MervinPraison/PraisonAI): Production-ready multi-agent framework with built-in deep research capabilities. ![GitHub Repo stars](https://img.shields.io/github/stars/MervinPraison/PraisonAI?style=social)
 - [AtomSearcher](https://github.com/antgroup/Research-Venus): An Automated deep research agent. ![GitHub Repo stars](https://img.shields.io/github/stars/antgroup/Research-Venus?style=social)
+- [Local Deep Research](https://github.com/LearningCircuit/local-deep-research): Local-first deep agentic research framework with multi-source retrieval (web, arXiv, PubMed, private documents) and 20+ research strategies. ![GitHub Repo stars](https://img.shields.io/github/stars/LearningCircuit/local-deep-research?style=social)
 
 ## Latest Research Papers
 


### PR DESCRIPTION
Hi! Adding [Local Deep Research](https://github.com/LearningCircuit/local-deep-research) (LDR) — an open-source deep agentic research framework that fits alongside the existing entries (gpt-researcher, DeerFlow, open-deep-research, etc.).

**Why I think it fits here:**
- Multi-step agentic research over web, arXiv, PubMed, Semantic Scholar, and private documents
- 20+ research strategies (including a LangGraph agent mode similar to `langgraph-deep-research`)
- Local-first — runs fully offline on Ollama / llama.cpp, also supports OpenAI-compatible endpoints
- ~95% on SimpleQA (n=500) on a single RTX 3090 with Qwen3-27B, plus 77% on xbench-DeepSearch ([benchmark dataset](https://huggingface.co/datasets/local-deep-research/ldr-benchmarks))
- 7.8k stars, MIT licensed, actively maintained

Happy to adjust the description if you'd prefer a different wording.