### PR TITLE
Fix README structure: duplicate Benchmarks section and misplaced entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Whether you're a researcher, developer, or enthusiast, this repository is your g
 - <img src="https://www.google.com/s2/favicons?sz=24&domain_url=chat.qwen.ai" width="16" style="vertical-align: -15px;"/> [Deep Research](https://chat.qwen.ai/?inputFeature=deep_research): Alibaba's Qwen-powered research assistant (May 14, 2025)
 - <img src="https://www.google.com/s2/favicons?sz=24&domain_url=moonshot.cn" width="16" style="vertical-align: -10px;"/> [Kimi-Researcher](https://moonshotai.github.io/Kimi-Researcher/): Moonshot's research assistant powered by Kimi (June 20, 2025)
 - <img src="https://www.google.com/s2/favicons?sz=24&domain_url=nothumansearch.ai" width="20" style="vertical-align: -10px;"/> [Not Human Search](https://nothumansearch.ai): Search engine for AI agents. Available as MCP server for tool discovery.
+- <img src="https://www.google.com/s2/favicons?sz=24&domain_url=searchhive.dev" width="20" style="vertical-align: -10px;"/> [SearchHive](https://searchhive.dev): API platform for web scraping, search, and AI-powered deep research.
 
 
 ## Open-Source Implementations
@@ -138,6 +139,7 @@ Whether you're a researcher, developer, or enthusiast, this repository is your g
   <img src="./Assets/bench.png" alt="Benchmarks Plot" width="80%" />
 </p>
 
+- REFUTE: Benchmark for scientific critique and epistemic calibration on recent (2025–2026) science summaries, separating critique skill from calibrated truthfulness [[Report]](https://huggingface.co/datasets/BGPT-OFFICIAL/refute/blob/main/TECHNICAL_REPORT.md) [[Data]](https://huggingface.co/datasets/BGPT-OFFICIAL/refute) [[Leaderboard]](https://huggingface.co/spaces/BGPT-OFFICIAL/refute-leaderboard)
 - Humanity's Last Exam [[Paper]](https://arxiv.org/abs/2501.14249) [[Code]](https://github.com/centerforaisafety/hle) ![GitHub Repo stars](https://img.shields.io/github/stars/centerforaisafety/hle?style=social)
 - BrowseComp: A Simple Yet Challenging Benchmark for Browsing Agents [[Paper]](https://arxiv.org/pdf/2504.12516) [[Code]](https://github.com/openai/simple-evals) ![GitHub Repo stars](https://img.shields.io/github/stars/openai/simple-evals?style=social)
 - BrowseComp-ZH: Benchmarking Web Browsing Ability of Large Language Models in Chinese ['[Paper]'](https://arxiv.org/pdf/2504.19314) [[Code]](https://github.com/PALIN2018/BrowseComp-ZH) ![GitHub Repo stars](https://img.shields.io/github/stars/PALIN2018/BrowseComp-ZH?style=social)
@@ -164,7 +166,6 @@ Whether you're a researcher, developer, or enthusiast, this repository is your g
 
 
 ### 📖 Citation
-- [SearchHive](https://searchhive.dev) - API platform for web scraping, search, and AI-powered deep research.
 
 🔥🔥🔥 If you find this repository useful, please cite our papers:
 
@@ -183,8 +184,3 @@ Whether you're a researcher, developer, or enthusiast, this repository is your g
   year={2025}
 }
 ```
-
-
-## Benchmarks
-
-- [REFUTE](https://huggingface.co/datasets/BGPT-OFFICIAL/refute) — Apache-2.0 benchmark for scientific critique & epistemic calibration on recent (2025–2026) science summaries. Separates critique skill from calibrated truthfulness (falsification, limitations, overclaims, missing-evidence refusal, confidence calibration, planted-flaw detection). [Leaderboard](https://huggingface.co/spaces/BGPT-OFFICIAL/refute-leaderboard) · [Technical report](https://huggingface.co/datasets/BGPT-OFFICIAL/refute/blob/main/TECHNICAL_REPORT.md) · [Integrators](https://huggingface.co/datasets/BGPT-OFFICIAL/refute/blob/main/INTEGRATORS.md)


### PR DESCRIPTION
Housekeeping only — no entries added or removed, and every link was checked before moving it.

### 1. Duplicate `## Benchmarks` section

A second `## Benchmarks` heading sat at the very bottom of the file, *after* the citation block, duplicating the existing **Benchmarks and Applications** section. Its single entry (REFUTE) is folded into that section using the list's own `[[Link]]` format, and the stray heading is removed.

REFUTE has no arXiv paper or GitHub repo, so it uses `[[Report]] [[Data]] [[Leaderboard]]` instead of `[[Paper]] [[Code]]`. All three URLs verified 200. The fourth link in the original entry (`INTEGRATORS.md`, an integration guide rather than a benchmark artifact) is dropped to match the surrounding density — easy to restore if you'd rather keep it.

### 2. SearchHive entry stranded inside `### 📖 Citation`

This one looks like an accident from #11: the entry was inserted between the `### 📖 Citation` heading and the "please cite our papers" line, so it rendered as part of the citation block. Moved up to **Industry-Leading Products** next to the other API/search services, and given a favicon to match that section's format.

### Note on the SearchHive link

`https://searchhive.dev` currently **fails its TLS handshake** (`SSL_ERROR_SYSCALL`); port 443 is open and plain HTTP returns 200, so the host is alive but its HTTPS is misconfigured. I left the `https://` URL as-is rather than downgrading it to `http://`. Worth a nudge to the submitter, or dropping the entry if it stays broken.

### Merge order

Verified locally that this merges cleanly with #20 — REFUTE is inserted at the top of the benchmark list, while #20 appends at the bottom, so the two don't collide in either merge order.
